### PR TITLE
Don't manipulate the Turbo Frame itself

### DIFF
--- a/public/styles/content.css
+++ b/public/styles/content.css
@@ -1,41 +1,41 @@
-body.hotwire-dev-tools-highlight-turbo-frames {
-  & turbo-frame {
-    display: block;
-    border-radius: 5px;
-  }
+.hotwire-dev-tools-highlight-overlay-turbo-frame {
+  position: absolute;
+  pointer-events: none;
+  border-radius: 5px;
+}
 
-  & .turbo-frame-info-badge-container {
-    position: relative;
-  }
+.hotwire-dev-tools-turbo-frame-info-badge-container {
+  position: relative;
+  pointer-events: all;
+}
 
-  & .turbo-frame-info-badge {
-    position: absolute;
-    z-index: 1000;
-    top: -20px;
-    height: 20px;
-    color: #fff;
-    padding: 0 5px;
-    border-radius: 5px;
-    font-size: 12px;
-    font-weight: bold;
-    cursor: pointer;
-    white-space: nowrap;
-    overflow: hidden;
-    width: 18px;
-    opacity: 0.1;
-    transition:
-      opacity 0.3s,
-      width 0.3s;
-  }
+.hotwire-dev-tools-turbo-frame-info-badge {
+  position: absolute;
+  z-index: 1000;
+  top: -20px;
+  height: 20px;
+  color: #fff;
+  padding: 0 5px;
+  border-radius: 5px;
+  font-size: 12px;
+  font-weight: bold;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  width: 18px;
+  opacity: 0.1;
+  transition:
+    opacity 0.3s,
+    width 0.3s;
+}
 
-  & .turbo-frame-info-badge:hover {
-    opacity: 1;
-    width: fit-content;
-  }
+.hotwire-dev-tools-turbo-frame-info-badge:hover {
+  opacity: 1;
+  width: fit-content;
+}
 
-  & .turbo-frame-info-badge.copied {
-    animation: turboFrameScaleEffect 0.3s ease-in-out;
-  }
+.hotwire-dev-tools-turbo-frame-info-badge.copied {
+  animation: turboFrameScaleEffect 0.3s ease-in-out;
 }
 
 .hotwire-dev-tools-highlight-overlay {

--- a/src/content.js
+++ b/src/content.js
@@ -8,15 +8,10 @@ const detailPanel = new DetailPanel(devTool)
 
 const highlightTurboFrames = () => {
   if (!devTool.options.turbo.highlightFrames) {
-    document.body.classList.remove("hotwire-dev-tools-highlight-turbo-frames")
-    document.querySelectorAll("turbo-frame").forEach((frame) => {
-      frame.style.outline = ""
-      frame.querySelector(".turbo-frame-info-badge-container")?.remove()
-    })
+    document.querySelectorAll(".hotwire-dev-tools-highlight-overlay-turbo-frame").forEach((overlay) => overlay.remove())
     return
   }
 
-  document.body.classList.add("hotwire-dev-tools-highlight-turbo-frames")
   const { highlightFramesOutlineWidth, highlightFramesOutlineStyle, highlightFramesOutlineColor, highlightFramesBlacklist, ignoreEmptyFrames } = devTool.options.turbo
 
   let blacklistedFrames = []
@@ -28,39 +23,56 @@ const highlightTurboFrames = () => {
     }
   }
 
+  const windowScrollY = window.scrollY
+  const windowScrollX = window.scrollX
   document.querySelectorAll("turbo-frame").forEach((frame) => {
     const isEmpty = frame.innerHTML.trim() === ""
     const shouldIgnore = isEmpty && ignoreEmptyFrames
     if (blacklistedFrames.includes(frame) || shouldIgnore) {
-      frame.style.outline = ""
+      document.getElementById(`hotwire-dev-tools-highlight-overlay-${frame.id}`)?.remove()
       return
     }
 
-    frame.style.outlineStyle = highlightFramesOutlineStyle
-    frame.style.outlineWidth = highlightFramesOutlineWidth
-    frame.style.outlineColor = highlightFramesOutlineColor
+    const frameId = frame.id
+    const rect = frame.getBoundingClientRect()
+    let overlay = document.getElementById(`hotwire-dev-tools-highlight-overlay-${frameId}`)
+    if (!overlay) {
+      overlay = document.createElement("div")
+      overlay.id = `hotwire-dev-tools-highlight-overlay-${frameId}`
+      overlay.className = `hotwire-dev-tools-highlight-overlay-turbo-frame`
+    }
 
-    // Add a badge to the frame (or update the existing one)
-    const badgeClass = "turbo-frame-info-badge"
-    const existingBadge = frame.querySelector(`.${badgeClass}`)
+    overlay.style.top = `${rect.top + windowScrollY}px`
+    overlay.style.left = `${rect.left + windowScrollX}px`
+    overlay.style.width = `${rect.width}px`
+    overlay.style.height = `${rect.height}px`
+    overlay.style.outlineStyle = highlightFramesOutlineStyle
+    overlay.style.outlineWidth = highlightFramesOutlineWidth
+    overlay.style.outlineColor = highlightFramesOutlineColor
+
+    // Add a badge to the overlay (or update the existing one)
+    const badgeClass = "hotwire-dev-tools-turbo-frame-info-badge"
+    const existingBadge = overlay.querySelector(`.${badgeClass}`)
     if (existingBadge) {
       existingBadge.style.backgroundColor = highlightFramesOutlineColor
     } else {
       const badgeContainer = document.createElement("div")
-      badgeContainer.classList.add("turbo-frame-info-badge-container")
+      badgeContainer.classList.add("hotwire-dev-tools-turbo-frame-info-badge-container")
       badgeContainer.dataset.turboTemporary = true
 
       const badgeContent = document.createElement("span")
-      badgeContent.textContent = `ʘ #${frame.id}`
+      badgeContent.textContent = `ʘ #${frameId}`
       badgeContent.classList.add(badgeClass)
-      badgeContent.dataset.turboId = frame.id
+      badgeContent.dataset.turboId = frameId
       badgeContent.style.backgroundColor = highlightFramesOutlineColor
       badgeContent.addEventListener("click", handleTurboFrameBadgeClick)
       badgeContent.addEventListener("animationend", handleTurboFrameBadgeAnimationEnd)
 
       badgeContainer.appendChild(badgeContent)
-      frame.insertAdjacentElement("afterbegin", badgeContainer)
+      overlay.insertAdjacentElement("afterbegin", badgeContainer)
     }
+
+    document.body.appendChild(overlay)
   })
 }
 

--- a/src/content.js
+++ b/src/content.js
@@ -72,7 +72,9 @@ const highlightTurboFrames = () => {
       overlay.insertAdjacentElement("afterbegin", badgeContainer)
     }
 
-    document.body.appendChild(overlay)
+    if (!overlay.parentNode) {
+      document.body.appendChild(overlay)
+    }
   })
 }
 


### PR DESCRIPTION
closes #18 

This PR introduces a new approach to highlighting Turbo Frames.
Instead of modifying the Turbo Frame itself, we add an additional div for each Turbo Frame and apply our styling to this div.
The added div will have a `position: absolute;` property and be placed on top of the Turbo Frames.

This change results in slightly decreased performance because more elements are appended to the DOM. However, it minimizes the risk of unwanted layout changes, which I believe justifies the performance impact.
If users with hundreds of Turbo Frames on a page notice a performance issue, we have solutions such as the Turbo Frame blacklist or page-specific option changes.

