### PR TITLE
Make highlighting Turbo Frames with an extra overlay element optional

### DIFF
--- a/public/popup.html
+++ b/public/popup.html
@@ -64,6 +64,11 @@
             <label for="turbo-highlight-frames-ignore-empty">Ignore empty Frames</label>
           </div>
 
+          <div>
+            <input type="checkbox" id="turbo-highlight-frames-with-overlay" class="ms-0" />
+            <label for="turbo-highlight-frames-with-overlay" title="Instead of altering the Turbo Frame itself, we render an overlay on top of the Frame.">Highlight with overlay</label>
+          </div>
+
           <input type="text" class="m-0" id="turbo-highlight-frames-blacklist" placeholder="CSS selector to ignore specific Frames" />
         </div>
 

--- a/public/styles/content.css
+++ b/public/styles/content.css
@@ -1,3 +1,10 @@
+body.hotwire-dev-tools-highlight-turbo-frames {
+  & turbo-frame {
+    display: block;
+    border-radius: 5px;
+  }
+}
+
 .hotwire-dev-tools-highlight-overlay-turbo-frame {
   position: absolute;
   pointer-events: none;

--- a/src/content.js
+++ b/src/content.js
@@ -8,11 +8,20 @@ const detailPanel = new DetailPanel(devTool)
 
 const highlightTurboFrames = () => {
   if (!devTool.options.turbo.highlightFrames) {
+    document.body.classList.remove("hotwire-dev-tools-highlight-turbo-frames")
+    document.querySelectorAll("turbo-frame").forEach((frame) => {
+      frame.style.outline = ""
+      frame.querySelector(".turbo-frame-info-badge-container")?.remove()
+    })
     document.querySelectorAll(".hotwire-dev-tools-highlight-overlay-turbo-frame").forEach((overlay) => overlay.remove())
     return
   }
 
-  const { highlightFramesOutlineWidth, highlightFramesOutlineStyle, highlightFramesOutlineColor, highlightFramesBlacklist, ignoreEmptyFrames } = devTool.options.turbo
+  const { highlightFramesOutlineWidth, highlightFramesOutlineStyle, highlightFramesOutlineColor, highlightFramesBlacklist, highlightFramesWithOverlay, ignoreEmptyFrames } = devTool.options.turbo
+
+  if (!highlightFramesWithOverlay) {
+    document.body.classList.add("hotwire-dev-tools-highlight-turbo-frames")
+  }
 
   let blacklistedFrames = []
   if (highlightFramesBlacklist) {
@@ -29,51 +38,79 @@ const highlightTurboFrames = () => {
     const isEmpty = frame.innerHTML.trim() === ""
     const shouldIgnore = isEmpty && ignoreEmptyFrames
     if (blacklistedFrames.includes(frame) || shouldIgnore) {
+      frame.style.outline = ""
       document.getElementById(`hotwire-dev-tools-highlight-overlay-${frame.id}`)?.remove()
       return
     }
 
-    const frameId = frame.id
-    const rect = frame.getBoundingClientRect()
-    let overlay = document.getElementById(`hotwire-dev-tools-highlight-overlay-${frameId}`)
-    if (!overlay) {
-      overlay = document.createElement("div")
-      overlay.id = `hotwire-dev-tools-highlight-overlay-${frameId}`
-      overlay.className = `hotwire-dev-tools-highlight-overlay-turbo-frame`
-    }
+    if (highlightFramesWithOverlay) {
+      const frameId = frame.id
+      const rect = frame.getBoundingClientRect()
+      let overlay = document.getElementById(`hotwire-dev-tools-highlight-overlay-${frameId}`)
+      if (!overlay) {
+        overlay = document.createElement("div")
+        overlay.id = `hotwire-dev-tools-highlight-overlay-${frameId}`
+        overlay.className = `hotwire-dev-tools-highlight-overlay-turbo-frame`
+      }
 
-    overlay.style.top = `${rect.top + windowScrollY}px`
-    overlay.style.left = `${rect.left + windowScrollX}px`
-    overlay.style.width = `${rect.width}px`
-    overlay.style.height = `${rect.height}px`
-    overlay.style.outlineStyle = highlightFramesOutlineStyle
-    overlay.style.outlineWidth = highlightFramesOutlineWidth
-    overlay.style.outlineColor = highlightFramesOutlineColor
+      overlay.style.top = `${rect.top + windowScrollY}px`
+      overlay.style.left = `${rect.left + windowScrollX}px`
+      overlay.style.width = `${rect.width}px`
+      overlay.style.height = `${rect.height}px`
+      overlay.style.outlineStyle = highlightFramesOutlineStyle
+      overlay.style.outlineWidth = highlightFramesOutlineWidth
+      overlay.style.outlineColor = highlightFramesOutlineColor
 
-    // Add a badge to the overlay (or update the existing one)
-    const badgeClass = "hotwire-dev-tools-turbo-frame-info-badge"
-    const existingBadge = overlay.querySelector(`.${badgeClass}`)
-    if (existingBadge) {
-      existingBadge.style.backgroundColor = highlightFramesOutlineColor
+      // Add a badge to the overlay (or update the existing one)
+      const badgeClass = "hotwire-dev-tools-turbo-frame-info-badge"
+      const existingBadge = overlay.querySelector(`.${badgeClass}`)
+      if (existingBadge) {
+        existingBadge.style.backgroundColor = highlightFramesOutlineColor
+      } else {
+        const badgeContainer = document.createElement("div")
+        badgeContainer.classList.add("hotwire-dev-tools-turbo-frame-info-badge-container")
+        badgeContainer.dataset.turboTemporary = true
+
+        const badgeContent = document.createElement("span")
+        badgeContent.textContent = `ʘ #${frameId}`
+        badgeContent.classList.add(badgeClass)
+        badgeContent.dataset.turboId = frameId
+        badgeContent.style.backgroundColor = highlightFramesOutlineColor
+        badgeContent.addEventListener("click", handleTurboFrameBadgeClick)
+        badgeContent.addEventListener("animationend", handleTurboFrameBadgeAnimationEnd)
+
+        badgeContainer.appendChild(badgeContent)
+        overlay.insertAdjacentElement("afterbegin", badgeContainer)
+      }
+
+      if (!overlay.parentNode) {
+        document.body.appendChild(overlay)
+      }
     } else {
-      const badgeContainer = document.createElement("div")
-      badgeContainer.classList.add("hotwire-dev-tools-turbo-frame-info-badge-container")
-      badgeContainer.dataset.turboTemporary = true
+      frame.style.outlineStyle = highlightFramesOutlineStyle
+      frame.style.outlineWidth = highlightFramesOutlineWidth
+      frame.style.outlineColor = highlightFramesOutlineColor
+      // Add a badge to the frame (or update the existing one)
+      const badgeClass = "hotwire-dev-tools-turbo-frame-info-badge"
+      const existingBadge = frame.querySelector(`.${badgeClass}`)
+      if (existingBadge) {
+        existingBadge.style.backgroundColor = highlightFramesOutlineColor
+      } else {
+        const badgeContainer = document.createElement("div")
+        badgeContainer.classList.add("hotwire-dev-tools-turbo-frame-info-badge-container")
+        badgeContainer.dataset.turboTemporary = true
 
-      const badgeContent = document.createElement("span")
-      badgeContent.textContent = `ʘ #${frameId}`
-      badgeContent.classList.add(badgeClass)
-      badgeContent.dataset.turboId = frameId
-      badgeContent.style.backgroundColor = highlightFramesOutlineColor
-      badgeContent.addEventListener("click", handleTurboFrameBadgeClick)
-      badgeContent.addEventListener("animationend", handleTurboFrameBadgeAnimationEnd)
+        const badgeContent = document.createElement("span")
+        badgeContent.textContent = `ʘ #${frame.id}`
+        badgeContent.classList.add(badgeClass)
+        badgeContent.dataset.turboId = frame.id
+        badgeContent.style.backgroundColor = highlightFramesOutlineColor
+        badgeContent.addEventListener("click", handleTurboFrameBadgeClick)
+        badgeContent.addEventListener("animationend", handleTurboFrameBadgeAnimationEnd)
 
-      badgeContainer.appendChild(badgeContent)
-      overlay.insertAdjacentElement("afterbegin", badgeContainer)
-    }
-
-    if (!overlay.parentNode) {
-      document.body.appendChild(overlay)
+        badgeContainer.appendChild(badgeContent)
+        frame.insertAdjacentElement("afterbegin", badgeContainer)
+      }
     }
   })
 }

--- a/src/lib/devtool.js
+++ b/src/lib/devtool.js
@@ -91,6 +91,7 @@ export default class Devtool {
         highlightFramesOutlineStyle: "dashed",
         highlightFramesOutlineColor: "#5cd8e5",
         highlightFramesBlacklist: "",
+        highlightFramesWithOverlay: false,
         ignoreEmptyFrames: false,
         consoleLogTurboStreams: false,
       },

--- a/src/popup.js
+++ b/src/popup.js
@@ -11,6 +11,7 @@ const turboHighlightFramesOutlineColor = document.getElementById("turbo-highligh
 const turboHighlightFramesBlacklist = document.getElementById("turbo-highlight-frames-blacklist")
 const turboHighlightFramesToggles = document.querySelectorAll(".turbo-highlight-frames-toggle-element")
 const turboHighlightFramesIgnoreEmpty = document.getElementById("turbo-highlight-frames-ignore-empty")
+const turboHighlightFramesWithOverlay = document.getElementById("turbo-highlight-frames-with-overlay")
 const turboConsoleLogTurboStreams = document.getElementById("turbo-console-log-turbo-streams")
 
 const stimulusHighlightControllers = document.getElementById("stimulus-highlight-controllers")
@@ -52,6 +53,7 @@ const initializeForm = async (options) => {
 
   turboHighlightFrames.checked = turbo.highlightFrames
   turboConsoleLogTurboStreams.checked = turbo.consoleLogTurboStreams
+  turboHighlightFramesWithOverlay.checked = turbo.highlightFramesWithOverlay
   turboHighlightFramesIgnoreEmpty.checked = turbo.ignoreEmptyFrames
   turboHighlightFramesOutlineColor.value = turbo.highlightFramesOutlineColor
   turboHighlightFramesOutlineStyle.value = turbo.highlightFramesOutlineStyle
@@ -142,6 +144,11 @@ const setupEventListeners = (options) => {
 
   turboConsoleLogTurboStreams.addEventListener("change", (event) => {
     turbo.consoleLogTurboStreams = event.target.checked
+    saveOptions(options)
+  })
+
+  turboHighlightFramesWithOverlay.addEventListener("change", (event) => {
+    turbo.highlightFramesWithOverlay = event.target.checked
     saveOptions(options)
   })
 


### PR DESCRIPTION
In PR #19, we introduced a way to highlight Turbo Frames using additional elements in the DOM instead of manipulating the Turbo Frame itself.

This solves some of the problems mentioned in #18 but introduces others. It just isn't a good solution. It’s not precise, especially when the Frame loads asynchronously. It also adds quite a lot of extra DOM manipulation, which results in poor performance, for example, when visiting the Hey calendar with hundreds of Turbo Frames.

I suggest we keep the overlay functionality until we find a better solution but make the previous approach of manipulating the frame itself the default. Most pages seem to work well with this approach. Anyone who experiences layout shifts due to this naive approach can switch to the "overlay approach".