### PR TITLE
Check if the options needs to be saved in scope of the current origin

### DIFF
--- a/src/lib/devtool.js
+++ b/src/lib/devtool.js
@@ -32,10 +32,14 @@ export default class Devtool {
     return pageOptions[this.origin]?.options
   }
 
-  saveOptions = (options, saveToOriginStore = false) => {
+  saveOptions = async (options, saveToOriginStore = null) => {
     const newOptions = { ...this.options, ...options }
     let dataToStore = newOptions
     let key = "options"
+
+    if (saveToOriginStore === null) {
+      saveToOriginStore = await this.originOptionsExist()
+    }
 
     if (saveToOriginStore) {
       dataToStore = this.origin ? { options: newOptions } : newOptions


### PR DESCRIPTION
Before this change, the tab navigation in the detail panel would not work if you had enabled scoped options.    
This because, when `saveOptions()` was called from the `DetailPanel` on a navigation event, we would always store the `currentTab` in the global store instead of the scoped one. 