### PR TITLE
Always show the detail panel when enabling it

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -182,6 +182,7 @@ const setupEventListeners = (options) => {
   detailPanelShow.addEventListener("change", (event) => {
     const showDetailPanel = event.target.checked
     detailPanel.show = showDetailPanel
+    detailPanel.collapsed = false
     toggleInputs(detailPanelToggles, showDetailPanel)
 
     const anyTabActive = detailPanelShowStimulusTab.checked || detailPanelShowTurboFrameTab.checked || detailPanelShowTurboStreamTab.checked


### PR DESCRIPTION
Before this change, when the detail panel was collapsed and the panel was disabled & enabled in the popup -> the panel would still be collapsed. This can we confusing as one can expect to see the panel after enabling it.