### PR TITLE
Ensure Stimulus controllers are registered correctly in Firefox

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -181,7 +181,7 @@ const handleWindowMessage = (event) => {
 
   switch (event.data.message) {
     case "stimulusController":
-      if (event.data.registeredControllers && event.data.registeredControllers.constructor === Array) {
+      if (event.data.registeredControllers) {
         devTool.registeredStimulusControllers = event.data.registeredControllers
         renderDetailPanel()
       }


### PR DESCRIPTION
Before this change, there was a bug in Firefox where the registered Stimulus controllers on the `window.Stimulus` object were never saved.
This happened because `event.data.registeredControllers.constructor === Array` always returned `false`.
For some reason, this array detection method didn't work in Firefox.
I'm not going to investigate further, since I don't think we really need this check.