### PR TITLE
Wait until the CSS for the detail panel is loaded, before rendering the panel

### DIFF
--- a/src/components/detail_panel.js
+++ b/src/components/detail_panel.js
@@ -18,8 +18,8 @@ export default class DetailPanel {
     this.shadowRoot = this.shadowContainer.attachShadow({ mode: "open" })
   }
 
-  render = debounce(() => {
-    this.injectCSSToShadowRoot()
+  render = debounce(async () => {
+    await this.injectCSSToShadowRoot()
     this.createOrUpdateDetailPanel()
 
     this.listenForTabNavigation()


### PR DESCRIPTION
Before this change, it was possible that the panel would render before the CSS was loaded, which would cause some ugly flickering.