### PR TITLE
Use user-selected colors for element highlighting

### DIFF
--- a/public/styles/content.css
+++ b/public/styles/content.css
@@ -46,18 +46,9 @@ body.hotwire-dev-tools-highlight-turbo-frames {
 }
 
 .hotwire-dev-tools-highlight-overlay {
-  background-color: rgba(92, 216, 229, 0.25);
+  opacity: 0.2;
   position: relative;
   z-index: 9999999;
-}
-
-.hotwire-dev-tools-stimulus-highlight-overlay {
-  background-color: rgba(119, 232, 185, 0.25);
-}
-
-.hotwire-dev-tools-turbo-frame-highlight-overlay,
-.hotwire-dev-tools-turbo-stream-highlight-overlay {
-  background-color: rgba(92, 216, 229, 0.25);
 }
 
 @keyframes turboFrameScaleEffect {

--- a/src/components/detail_panel.js
+++ b/src/components/detail_panel.js
@@ -180,11 +180,11 @@ export default class DetailPanel {
 
   #handleMouseEnterTurboStream = (event) => {
     const selector = event.currentTarget.dataset.targetSelector
-    addHighlightOverlay(selector, "hotwire-dev-tools-turbo-stream-highlight-overlay", this.devTool.options.turbo.highlightFramesOutlineColor)
+    addHighlightOverlay(selector, this.devTool.options.turbo.highlightFramesOutlineColor)
   }
 
   #handleMouseLeaveTurboStream = () => {
-    removeHighlightOverlay(".hotwire-dev-tools-turbo-stream-highlight-overlay")
+    removeHighlightOverlay()
   }
 
   #handleClickTurboStream = (event) => {
@@ -203,20 +203,20 @@ export default class DetailPanel {
 
   #handleMouseEnterStimulusController = (event) => {
     const controllerId = event.currentTarget.getAttribute("data-stimulus-controller-id")
-    addHighlightOverlay(`[data-controller="${controllerId}"]`, "hotwire-dev-tools-stimulus-highlight-overlay", this.devTool.options.stimulus.highlightControllersOutlineColor)
+    addHighlightOverlay(`[data-controller="${controllerId}"]`, this.devTool.options.stimulus.highlightControllersOutlineColor)
   }
 
   #handleMouseLeaveStimulusController = () => {
-    removeHighlightOverlay(".hotwire-dev-tools-stimulus-highlight-overlay")
+    removeHighlightOverlay()
   }
 
   #handleMouseEnterTurboFrame = (event) => {
     const frameId = event.currentTarget.getAttribute("data-turbo-frame-id")
-    addHighlightOverlay(`#${frameId}`, "hotwire-dev-tools-turbo-frame-highlight-overlay", this.devTool.options.turbo.highlightFramesOutlineColor)
+    addHighlightOverlay(`#${frameId}`, this.devTool.options.turbo.highlightFramesOutlineColor)
   }
 
   #handleMouseLeaveTurboFrame = () => {
-    removeHighlightOverlay(".hotwire-dev-tools-turbo-frame-highlight-overlay")
+    removeHighlightOverlay()
   }
 
   get panelHeader() {

--- a/src/components/detail_panel.js
+++ b/src/components/detail_panel.js
@@ -180,7 +180,7 @@ export default class DetailPanel {
 
   #handleMouseEnterTurboStream = (event) => {
     const selector = event.currentTarget.dataset.targetSelector
-    addHighlightOverlay(selector, "hotwire-dev-tools-turbo-stream-highlight-overlay")
+    addHighlightOverlay(selector, "hotwire-dev-tools-turbo-stream-highlight-overlay", this.devTool.options.turbo.highlightFramesOutlineColor)
   }
 
   #handleMouseLeaveTurboStream = () => {
@@ -203,7 +203,7 @@ export default class DetailPanel {
 
   #handleMouseEnterStimulusController = (event) => {
     const controllerId = event.currentTarget.getAttribute("data-stimulus-controller-id")
-    addHighlightOverlay(`[data-controller="${controllerId}"]`, "hotwire-dev-tools-stimulus-highlight-overlay")
+    addHighlightOverlay(`[data-controller="${controllerId}"]`, "hotwire-dev-tools-stimulus-highlight-overlay", this.devTool.options.stimulus.highlightControllersOutlineColor)
   }
 
   #handleMouseLeaveStimulusController = () => {
@@ -212,7 +212,7 @@ export default class DetailPanel {
 
   #handleMouseEnterTurboFrame = (event) => {
     const frameId = event.currentTarget.getAttribute("data-turbo-frame-id")
-    addHighlightOverlay(`#${frameId}`, "hotwire-dev-tools-turbo-frame-highlight-overlay")
+    addHighlightOverlay(`#${frameId}`, "hotwire-dev-tools-turbo-frame-highlight-overlay", this.devTool.options.turbo.highlightFramesOutlineColor)
   }
 
   #handleMouseLeaveTurboFrame = () => {

--- a/src/lib/highlight.js
+++ b/src/lib/highlight.js
@@ -1,4 +1,4 @@
-export const addHighlightOverlay = (selector, className) => {
+export const addHighlightOverlay = (selector, className, color = "#77e8b9") => {
   const elements = document.querySelectorAll(selector)
   elements.forEach((element) => {
     const rect = element.getBoundingClientRect()
@@ -9,6 +9,7 @@ export const addHighlightOverlay = (selector, className) => {
     overlay.style.left = `${rect.left + window.scrollX}px`
     overlay.style.width = `${rect.width}px`
     overlay.style.height = `${rect.height}px`
+    overlay.style.backgroundColor = color
     document.body.appendChild(overlay)
   })
 }

--- a/src/lib/highlight.js
+++ b/src/lib/highlight.js
@@ -1,9 +1,9 @@
-export const addHighlightOverlay = (selector, className, color = "#77e8b9") => {
+export const addHighlightOverlay = (selector, color = "#77e8b9") => {
   const elements = document.querySelectorAll(selector)
   elements.forEach((element) => {
     const rect = element.getBoundingClientRect()
     const overlay = document.createElement("div")
-    overlay.className = `hotwire-dev-tools-highlight-overlay ${className}`
+    overlay.className = "hotwire-dev-tools-highlight-overlay"
     overlay.style.position = "absolute"
     overlay.style.top = `${rect.top + window.scrollY}px`
     overlay.style.left = `${rect.left + window.scrollX}px`
@@ -14,7 +14,7 @@ export const addHighlightOverlay = (selector, className, color = "#77e8b9") => {
   })
 }
 
-export const removeHighlightOverlay = (selector) => {
+export const removeHighlightOverlay = (selector = ".hotwire-dev-tools-highlight-overlay") => {
   const overlays = document.querySelectorAll(selector)
   overlays.forEach((overlay) => overlay.remove())
 }


### PR DESCRIPTION
Instead of predefined colors for element highlighting, we can reuse the user selected colors.    
That way, the highlighting will be consistent with maybe already existing outline color of the elements.