### PR TITLE
Handle tabs with non existing URL

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -232,6 +232,10 @@ const getCurrentTabOrigin = async () => {
         return reject(new Error("No active tab found"))
       }
 
+      if (!tabs[0].url) {
+        return reject(new Error("Active tab has no URL"))
+      }
+
       const origin = new URL(tabs[0].url).origin
       resolve(origin)
     })


### PR DESCRIPTION
Before this change, opening the popup in a tab without a URL (for example a blank _new page_ tab) caused the following error:
```
TypeError: Failed to construct 'URL': Invalid URL.
```

Possible fix for #49 