### PR TITLE
Prevent detail panel error at incoming Turbo Streams

### DIFF
--- a/src/components/detail_panel.js
+++ b/src/components/detail_panel.js
@@ -58,7 +58,7 @@ export default class DetailPanel {
   }
 
   addTurboStreamToDetailPanel = (event) => {
-    if (!this.isTabEnabled(TURBO_STREAM_TAB_ID)) return
+    if (!this.devTool.options.detailPanel.show || !this.isTabEnabled(TURBO_STREAM_TAB_ID)) return
 
     const turboStream = event.target
     const action = turboStream.getAttribute("action")


### PR DESCRIPTION
Before this change, the extension would throw an error because the destination element for the Turbo Stream `#hotwire-dev-tools-turbo-stream-tab` wasn't in the DOM. 