### PR TITLE
Add color preview in the popup for Firefox

### DIFF
--- a/public/popup.html
+++ b/public/popup.html
@@ -58,6 +58,7 @@
               <option value="solid">solid</option>
             </select>
 
+            <div class="color-preview d-none"></div>
             <input type="color" id="turbo-highlight-frames-outline-color" />
           </div>
 
@@ -117,6 +118,7 @@
               <option value="solid">solid</option>
             </select>
 
+            <div class="color-preview d-none"></div>
             <input type="color" id="stimulus-highlight-controllers-outline-color" />
           </div>
 

--- a/public/styles/hotwire_dev_tools_popup.css
+++ b/public/styles/hotwire_dev_tools_popup.css
@@ -176,6 +176,12 @@ body.no-transitions {
   }
 }
 
+.color-preview {
+  width: 80px;
+  height: 20px;
+  margin-left: 7px;
+}
+
 /* Utility classes */
 .d-none {
   display: none;

--- a/src/popup.js
+++ b/src/popup.js
@@ -56,6 +56,15 @@ const saveOptions = async (options) => {
   devTool.saveOptions(options, pageSpecificOptions.checked)
 }
 
+const showFirefoxColorPreview = () => {
+  if (!devTool.isFirefox) return
+
+  document.querySelectorAll(".color-preview").forEach((preview) => {
+    preview.classList.remove("d-none")
+    preview.style.backgroundColor = preview.nextElementSibling.value
+  })
+}
+
 const initializeForm = async (options) => {
   const originOptionsExist = await devTool.originOptionsExist()
   pageSpecificOptions.checked = originOptionsExist
@@ -89,10 +98,12 @@ const initializeForm = async (options) => {
     // In Firefox the color picker inside an extension popup doesn't really work (See https://github.com/leonvogt/hotwire-dev-tools/issues/20)
     // Workaround: Change the input type to text so the user can input the color manually
     turboHighlightFramesOutlineColor.type = "text"
-    turboHighlightFramesOutlineColor.placeholder = devTool.defaultOptions.turbo.highlightFramesOutlineColor
-
     stimulusHighlightControllersOutlineColor.type = "text"
-    stimulusHighlightControllersOutlineColor.placeholder = devTool.defaultOptions.stimulus.highlightControllersOutlineColor
+
+    turboHighlightFramesOutlineColor.value = options.turbo.highlightFramesOutlineColor
+    stimulusHighlightControllersOutlineColor.value = options.stimulus.highlightControllersOutlineColor
+
+    showFirefoxColorPreview()
   }
 
   const activeEvents = Array.from(options.monitor?.events || [])
@@ -159,8 +170,10 @@ const setupEventListeners = (options) => {
     saveOptions(options)
   })
 
-  turboHighlightFramesOutlineColor.addEventListener("change", (event) => {
+  turboHighlightFramesOutlineColor.addEventListener(devTool.isFirefox ? "input" : "change", (event) => {
     options.turbo.highlightFramesOutlineColor = event.target.value
+
+    showFirefoxColorPreview()
     saveOptions(options)
   })
 
@@ -206,8 +219,10 @@ const setupEventListeners = (options) => {
     saveOptions(options)
   })
 
-  stimulusHighlightControllersOutlineColor.addEventListener("change", (event) => {
+  stimulusHighlightControllersOutlineColor.addEventListener(devTool.isFirefox ? "input" : "change", (event) => {
     options.stimulus.highlightControllersOutlineColor = event.target.value
+
+    showFirefoxColorPreview()
     saveOptions(options)
   })
 


### PR DESCRIPTION
| Previously | Now |
|---|---|
|![image](https://github.com/user-attachments/assets/dafdbed2-5fa6-447e-a99b-b56e9aa7016e)|![image](https://github.com/user-attachments/assets/6d2f7919-9c9e-443a-ba62-b91becbc7246)|
