### PR TITLE
Hot Reload popup changes

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -295,7 +295,7 @@ window.addEventListener("turbo:frame-render", handleTurboFrameRender)
 
 // Listen for option changes made in the popup
 chrome.storage.onChanged.addListener((changes, area) => {
-  if (area === "sync" && (changes.options?.newValue || changes[LOCATION_ORIGIN]?.newValue)) {
+  if (changes.options?.newValue || changes[LOCATION_ORIGIN]?.newValue) {
     document.dispatchEvent(new CustomEvent("hotwire-dev-tools:options-changed"))
   }
 })


### PR DESCRIPTION
Hot Reload popup changes already worked in Chrome and Firefox.   

In Safari, the `area` param from the `onChanged` function is for some unknown reason always empty, which is why hot reloading wasn't working.

Simple fix: just ignore the area.
Worst-case: we update the content script a bit more often than needed.