### PR TITLE
Select all Turbo events by default

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -273,10 +273,14 @@ const setupEventListeners = (options) => {
   monitorEvents.addEventListener("change", (event) => {
     const checked = event.target.checked
     toggleInputs(monitorEventsToggles, checked)
-    if (!checked) {
+    if (checked) {
+      const allCheckboxes = document.querySelectorAll(".monitor-events-checkbox-container input[type='checkbox']")
+      allCheckboxes.forEach((checkbox) => (checkbox.checked = true))
+      options.monitor.events = MONITORING_EVENTS
+    } else {
       options.monitor.events = []
-      saveOptions(options)
     }
+    saveOptions(options)
   })
 
   monitorEventsCheckboxContainer.addEventListener("change", (event) => {


### PR DESCRIPTION
With this PR, all monitorable Turbo events will be selected by default if 'Monitor Events' is enabled.

![screenshot 2025-04-12 at 00 46 54@2x](https://github.com/user-attachments/assets/c120ad07-56c2-4566-853b-c3daac4cc7be)
