### PR TITLE
Don't log warnings for unregistered bridge component

### DIFF
--- a/src/lib/diagnostics_checker.js
+++ b/src/lib/diagnostics_checker.js
@@ -35,9 +35,15 @@ export default class DiagnosticsChecker {
     if (registeredStimulusControllers.length === 0) return
 
     DOMScanner.uniqueStimulusControllerIdentifiers.forEach((controllerId) => {
-      const controllerRegistered = registeredStimulusControllers.includes(controllerId)
+      // Bridge components are only registered in the Mobile app,
+      // so we don't want to show warnings for them in the web app.
+      // Ideally, we'd verify whether a controller is truly a bridge component,
+      // but since we have limited insight into the Stimulus application,
+      // we just use a simple prefix check.
+      const isBridgeComponent = controllerId.startsWith("native--") || controllerId.startsWith("bridge--")
 
-      if (!controllerRegistered) {
+      const controllerRegistered = registeredStimulusControllers.includes(controllerId)
+      if (!controllerRegistered && !isBridgeComponent) {
         this.printWarning(`The Stimulus controller '${controllerId}' does not appear to be registered. Learn more about registering Stimulus controllers here: https://stimulus.hotwired.dev/handbook/installing.`)
       }
     })


### PR DESCRIPTION
Before this PR, the extension would log warnings, for every bridge component that is found on the page. Like `data-controller="bridge--button"` or `data-controller="native--bridge"`:   
![screenshot 2025-04-17 at 17 15 13@2x](https://github.com/user-attachments/assets/d304e61f-8d2e-4323-97d3-691f36846f98)

Since bridge components are only registered in the mobile app, it doesn't make a lot of sense to log these warnings in the web app. This PR removes the logging of these warnings by checking if the controller starts with `bridge--` or `native--`. This isn't ideal, but until we have more insight into the Stimulus application, it will hopefully result in less noise in the console.