### PR TITLE
Group Turbo events

### DIFF
--- a/public/styles/hotwire_dev_tools_popup.css
+++ b/public/styles/hotwire_dev_tools_popup.css
@@ -120,6 +120,10 @@ button:hover {
   color: var(--text-muted-color);
 }
 
+.monitor-events-group {
+  margin-bottom: 1em;
+}
+
 /* Custom checkbox toggles */
 .toggle {
   cursor: pointer;

--- a/public/styles/hotwire_dev_tools_popup.css
+++ b/public/styles/hotwire_dev_tools_popup.css
@@ -124,6 +124,10 @@ button:hover {
   margin-bottom: 1em;
 }
 
+.monitor-events-group-title {
+  cursor: pointer;
+}
+
 /* Custom checkbox toggles */
 .toggle {
   cursor: pointer;

--- a/src/lib/monitoring_events.js
+++ b/src/lib/monitoring_events.js
@@ -22,3 +22,12 @@ export const MONITORING_EVENTS = [
   "turbo:before-prefetch",
   "turbo:fetch-request-error",
 ]
+
+export const MONITORING_EVENT_GROUPS = {
+  Document: ["turbo:click", "turbo:before-visit", "turbo:visit", "turbo:before-cache", "turbo:before-render", "turbo:render", "turbo:load"],
+  "Page Refreshes": ["turbo:morph", "turbo:before-morph-element", "turbo:before-morph-attribute", "turbo:morph-element"],
+  Forms: ["turbo:submit-start", "turbo:submit-end"],
+  Frames: ["turbo:before-frame-render", "turbo:frame-render", "turbo:frame-load", "turbo:frame-missing"],
+  Streams: ["turbo:before-stream-render"],
+  "HTTP Requests": ["turbo:before-fetch-request", "turbo:before-fetch-response", "turbo:before-prefetch", "turbo:fetch-request-error"],
+}

--- a/src/popup.js
+++ b/src/popup.js
@@ -293,6 +293,9 @@ const setupEventListeners = (options) => {
       options.monitor.events = []
     }
     saveOptions(options)
+
+    // Scoll the first event group into view
+    document.querySelector(".monitor-events-group-title").scrollIntoView({ behavior: "smooth", block: "center" })
   })
 
   monitorEventsCheckboxContainer.addEventListener("change", (event) => {

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,5 +1,5 @@
 import Devtool from "./lib/devtool"
-import { MONITORING_EVENTS } from "./lib/monitoring_events"
+import { MONITORING_EVENTS, MONITORING_EVENT_GROUPS } from "./lib/monitoring_events"
 
 const devTool = new Devtool()
 
@@ -108,21 +108,32 @@ const initializeForm = async (options) => {
 
   const activeEvents = Array.from(options.monitor?.events || [])
 
-  MONITORING_EVENTS.forEach((event) => {
-    const wrapper = document.createElement("div")
-    const checkbox = document.createElement("input")
-    checkbox.type = "checkbox"
-    checkbox.id = `monitor-${event}`
-    checkbox.value = event
-    checkbox.checked = activeEvents.includes(event)
+  Object.entries(MONITORING_EVENT_GROUPS).forEach(([groupName, events]) => {
+    const groupContainer = document.createElement("div")
+    groupContainer.classList.add("monitor-events-group")
 
-    const label = document.createElement("label")
-    label.htmlFor = `monitor-${event}`
-    label.textContent = event
+    const groupTitle = document.createElement("strong")
+    groupTitle.textContent = groupName
+    groupContainer.appendChild(groupTitle)
 
-    wrapper.appendChild(checkbox)
-    wrapper.appendChild(label)
-    document.querySelector(".monitor-events-checkbox-container").appendChild(wrapper)
+    events.forEach((event) => {
+      const wrapper = document.createElement("div")
+      const checkbox = document.createElement("input")
+      checkbox.type = "checkbox"
+      checkbox.id = `monitor-${event}`
+      checkbox.value = event
+      checkbox.checked = activeEvents.includes(event)
+
+      const label = document.createElement("label")
+      label.htmlFor = `monitor-${event}`
+      label.textContent = event
+
+      wrapper.appendChild(checkbox)
+      wrapper.appendChild(label)
+      groupContainer.appendChild(wrapper)
+    })
+
+    monitorEventsCheckboxContainer.appendChild(groupContainer)
   })
 
   toggleInputs(turboHighlightFramesToggles, options.turbo.highlightFrames)

--- a/src/popup.js
+++ b/src/popup.js
@@ -114,6 +114,7 @@ const initializeForm = async (options) => {
 
     const groupTitle = document.createElement("strong")
     groupTitle.textContent = groupName
+    groupTitle.classList.add("monitor-events-group-title")
     groupContainer.appendChild(groupTitle)
 
     events.forEach((event) => {
@@ -305,6 +306,26 @@ const setupEventListeners = (options) => {
     }
 
     saveOptions(options)
+  })
+
+  monitorEventsCheckboxContainer.addEventListener("click", (event) => {
+    const element = event.target
+    if (element.classList.contains("monitor-events-group-title")) {
+      const checkboxes = element.parentElement.querySelectorAll("input[type='checkbox']")
+      const allChecked = Array.from(checkboxes).every((checkbox) => checkbox.checked)
+
+      checkboxes.forEach((checkbox) => {
+        checkbox.checked = !allChecked
+        const eventValue = checkbox.value
+        if (checkbox.checked) {
+          options.monitor.events.push(eventValue)
+        } else {
+          options.monitor.events = options.monitor.events.filter((event) => event !== eventValue)
+        }
+      })
+
+      saveOptions(options)
+    }
   })
 
   monitorEventsSelectAll.addEventListener("click", (event) => {


### PR DESCRIPTION
This PR adds groups to the Turbo events to make it easier to find the right ones.
Additionally, clicking on a group name selects the corresponding events.
The events are also scrolled into view, since depending on the screen size, they might not be visible after toggling the "Monitor events" option.


| Previously | Now |
| --- | --- |
| ![screenshot 2025-04-19 at 23 03 41@2x](https://github.com/user-attachments/assets/d6cf8cfc-56f4-4633-bb78-cf73f9a30c4c) | ![screenshot 2025-04-19 at 23 03 00@2x](https://github.com/user-attachments/assets/9b9affbd-9934-4d4a-a9a0-559aa54232c9)|
