### PR TITLE
Prevent UI flicker

### DIFF
--- a/src/browser_panel/panel/App.svelte
+++ b/src/browser_panel/panel/App.svelte
@@ -1,9 +1,18 @@
 <script>
-  import TurboTab from "./tabs/TurboTab.svelte"
+  import { getDevtoolInstance, setDevtoolInstance } from "../../lib/devtool.js"
   import { handleResize } from "../theme.svelte.js"
-  import { setDevtoolInstance } from "../../lib/devtool.js"
+  import TurboTab from "./tabs/TurboTab.svelte"
 
   setDevtoolInstance()
+  const devTool = getDevtoolInstance()
+  let devToolOptionsLoaded = $state(false)
+
+  const initializeDevToolOptions = async () => {
+    await devTool.setOptions()
+    devToolOptionsLoaded = true
+  }
+  initializeDevToolOptions()
+
   let currentTab = $state("turbo-tab")
 
   const addEventListeners = () => {
@@ -26,29 +35,35 @@
   }
 </script>
 
-<main {@attach addEventListeners}>
-  <div id="container">
-    <div class="tablist">
-      <button class="tablinks" class:active={currentTab == "turbo-tab"} onclick={updateTab} data-tab-id="turbo-tab">Turbo</button>
-      <button class="tablinks" class:active={currentTab == "stimulus-tab"} onclick={updateTab} data-tab-id="stimulus-tab">Stimulus</button>
-      <button class="tablinks" class:active={currentTab == "native-tab"} onclick={updateTab} data-tab-id="native-tab">Native</button>
-      <button class="tablinks" class:active={currentTab == "events-tab"} onclick={updateTab} data-tab-id="events-tab">Events</button>
-    </div>
+{#if devToolOptionsLoaded}
+  <main {@attach addEventListeners}>
+    <div id="container">
+      <div class="tablist">
+        <button class="tablinks" class:active={currentTab == "turbo-tab"} onclick={updateTab} data-tab-id="turbo-tab">Turbo</button>
+        <button class="tablinks" class:active={currentTab == "stimulus-tab"} onclick={updateTab} data-tab-id="stimulus-tab">Stimulus</button>
+        <button class="tablinks" class:active={currentTab == "native-tab"} onclick={updateTab} data-tab-id="native-tab">Native</button>
+        <button class="tablinks" class:active={currentTab == "events-tab"} onclick={updateTab} data-tab-id="events-tab">Events</button>
+      </div>
 
-    <div id="turbo-tab" class="tabcontent active">
-      <TurboTab />
-    </div>
+      <div id="turbo-tab" class="tabcontent active">
+        <TurboTab />
+      </div>
 
-    <div id="stimulus-tab" class="tabcontent">
-      <h2>Stimulus</h2>
-    </div>
+      <div id="stimulus-tab" class="tabcontent">
+        <h2>Stimulus</h2>
+      </div>
 
-    <div id="native-tab" class="tabcontent">
-      <h2>Native</h2>
-    </div>
+      <div id="native-tab" class="tabcontent">
+        <h2>Native</h2>
+      </div>
 
-    <div id="events-tab" class="tabcontent">
-      <h2>Events</h2>
+      <div id="events-tab" class="tabcontent">
+        <h2>Events</h2>
+      </div>
     </div>
+  </main>
+{:else}
+  <div class="loading-indicator">
+    <span>Loading Hotwire Dev Tools</span>
   </div>
-</main>
+{/if}

--- a/src/browser_panel/panel/tabs/TurboTab.svelte
+++ b/src/browser_panel/panel/tabs/TurboTab.svelte
@@ -23,7 +23,7 @@
   const ignoredAttributes = ["id", "loading", "src", "complete", "aria-busy", "busy"]
 
   const devTool = getDevtoolInstance()
-  let options = $state({})
+  let options = $state(devTool.options)
   let turboFrames = $state([])
   let turboStreams = $state([])
 
@@ -53,7 +53,7 @@
   }
 
   // Set the first Turbo Frame as selected if none is selected
-  $effect(async () => {
+  $effect(() => {
     turboFrames = getTurboFrames().sort((a, b) => a.id.localeCompare(b.id))
     turboStreams = getTurboStreams()
 
@@ -65,8 +65,6 @@
         stream: null,
       }
     }
-
-    options = await devTool.getOptions()
   })
 
   const scrollIntoView = debounce((element) => {

--- a/src/lib/devtool.js
+++ b/src/lib/devtool.js
@@ -9,8 +9,6 @@ export default class Devtool {
 
     this.origin = origin
     this.detailPanelCSSContent = null
-
-    this.setOptions()
   }
 
   setOptions = async () => {

--- a/src/popup.js
+++ b/src/popup.js
@@ -382,7 +382,7 @@ const getCurrentTabOrigin = async () => {
 
   versionString.textContent = devTool.version
 
-  const options = await devTool.getOptions()
-  initializeForm(options)
-  setupEventListeners(options)
+  await devTool.setOptions()
+  initializeForm(devTool.options)
+  setupEventListeners(devTool.options)
 })()


### PR DESCRIPTION
If a pane size of the dev tools gets updated by the user, we save it to the extension store.   
So when the user opens the panel again, the pane size is restored to the last used value.

Before this PR, the panel would load with the default size, and once the options were loaded, the size would be updated. This caused a flicker effect, which was not ideal.   

To prevent this, we now load the options in the main `App.svelte` file and wait for the options to be loaded before rendering the dev tools. This way, each tab will have the latest options applied immediately without any flicker.