### PR TITLE
Improve page reload handling

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,6 @@
 // This background script is running all the time and checks for connections,
 // from the browser devtools panel and the backend.
+// It sets up a two-way communication channel between the devtools panel and the backend script.
 
 import { isInspector, inspectorPortNameToTabId, PROXY } from "./browser_panel/ports"
 

--- a/src/browser_panel/page/backend.js
+++ b/src/browser_panel/page/backend.js
@@ -1,4 +1,4 @@
-import { HOTWIRE_DEV_TOOLS_PROXY_SOURCE } from "../ports"
+import { HOTWIRE_DEV_TOOLS_PROXY_SOURCE, HOTWIRE_DEV_TOOLS_BACKEND_SOURCE } from "../ports"
 import { BACKEND_TO_PANEL_MESSAGES, PANEL_TO_BACKEND_MESSAGES } from "../../lib/constants"
 import { addHighlightOverlayToElements, removeHighlightOverlay } from "../../utils/highlight"
 import { debounce, serializeHTMLElement, generateUUID } from "../../utils/utils"
@@ -100,7 +100,7 @@ function init() {
     _postMessage(payload) {
       window.postMessage(
         {
-          source: "hotwire-dev-tools-backend",
+          source: HOTWIRE_DEV_TOOLS_BACKEND_SOURCE,
           payload,
         },
         "*",
@@ -155,7 +155,7 @@ function init() {
   window.addEventListener("message", handshake)
 
   function handshake(e) {
-    if (e.data.source === HOTWIRE_DEV_TOOLS_PROXY_SOURCE && e.data.payload === "init") {
+    if (e.data.source === HOTWIRE_DEV_TOOLS_PROXY_SOURCE && e.data.payload === PANEL_TO_BACKEND_MESSAGES.INIT) {
       window.removeEventListener("message", handshake)
       window.addEventListener("message", handleMessages)
       devtoolsBackend.start()

--- a/src/browser_panel/panel/panel.js
+++ b/src/browser_panel/panel/panel.js
@@ -1,11 +1,12 @@
+// Entry point for the DevTools panel.
+// Initializes the Svelte app, injects the backend script into the inspected page,
+// and establishes a connection to the background.js for communication.
+
 import App from "./App.svelte"
 import { mount } from "svelte"
 
 import { inspectorPortName } from "../ports"
 import { handleBackendToPanelMessage } from "../messaging"
-
-// This file is the entrypoint for DevTool panel
-// It is loaded in the context of the DevTools panel and injects the backend script into the current tab / page
 
 if (chrome.devtools.panels.themeName === "dark") {
   document.body.classList.add("dark")
@@ -13,53 +14,168 @@ if (chrome.devtools.panels.themeName === "dark") {
   document.body.classList.remove("dark")
 }
 
-export default mount(App, {
-  target: document.querySelector("#app"),
-})
+// State management for connection attempts
+let connectionAttempts = 0
+let maxConnectionAttempts = 10
+let isConnecting = false
+let currentPort = null
 
 function connect() {
-  injectBackendScript(() => {
-    const port = chrome.runtime.connect({
-      name: inspectorPortName(chrome.devtools.inspectedWindow.tabId),
-    })
+  if (isConnecting) return
+  isConnecting = true
+  connectionAttempts++
 
-    let disconnected = false
+  console.log(`Connection attempt ${connectionAttempts}/${maxConnectionAttempts}`)
 
-    port.onDisconnect.addListener(() => {
-      disconnected = true
+  injectBackendScript()
+    .then(() => {
+      return createConnection()
     })
+    .then((port) => {
+      currentPort = port
+      connectionAttempts = 0 // Reset on success
+      isConnecting = false
+    })
+    .catch((error) => {
+      console.warn("Connection failed:", error)
+      isConnecting = false
 
-    port.onMessage.addListener(function (message) {
-      if (disconnected) return
-      handleBackendToPanelMessage(message, port)
+      if (connectionAttempts < maxConnectionAttempts) {
+        setTimeout(() => connect(), 500)
+      } else {
+        console.error("Max connection attempts reached. Backend injection failed.")
+        connectionAttempts = 0 // Reset for future attempts
+      }
     })
-  })
 }
 
-function onReload(reloadFunction) {
-  chrome.devtools.network.onNavigated.addListener(reloadFunction)
+function createConnection() {
+  return new Promise((resolve, reject) => {
+    try {
+      const port = chrome.runtime.connect({
+        name: inspectorPortName(chrome.devtools.inspectedWindow.tabId),
+      })
+
+      let disconnected = false
+
+      port.onDisconnect.addListener(() => {
+        disconnected = true
+      })
+
+      port.onMessage.addListener(function (message) {
+        if (disconnected) return
+        handleBackendToPanelMessage(message, port)
+      })
+
+      resolve(port)
+    } catch (error) {
+      reject(error)
+    }
+  })
 }
 
 // Inject backend.js in the same context as the actual page
-function injectBackendScript(callback) {
-  const scripURL = chrome.runtime.getURL("/dist/browser_panel/page/backend.js")
-  const script = `
-    (function() {
-      var script = document.constructor.prototype.createElement.call(document, 'script');
-      script.src = "${scripURL}";
-      script.id = "hotwire-dev-tools-backend-script"
-      document.documentElement.appendChild(script);
-    })()
-  `
-  chrome.devtools.inspectedWindow.eval(script, function (res, err) {
-    if (err) {
-      console.log(err)
-    }
-    callback()
+function injectBackendScript() {
+  return new Promise((resolve, reject) => {
+    const scriptId = "hotwire-dev-tools-backend-script"
+    const scriptURL = chrome.runtime.getURL("/dist/browser_panel/page/backend.js")
+
+    const injectionScript = `
+      (function() {
+        // Check if script is already injected
+        if (document.getElementById('${scriptId}')) {
+          return 'already-injected';
+        }
+
+        // Function to inject script
+        function injectScript() {
+          const script = document.createElement('script');
+          script.src = "${scriptURL}";
+          script.id = "${scriptId}";
+          script.async = true;
+
+          // Add error handling
+          script.onerror = function() {
+            console.error('Failed to load backend script');
+          };
+
+          const target = document.head || document.documentElement;
+          if (target) {
+            target.appendChild(script);
+            return 'injected';
+          }
+          return 'no-target';
+        }
+
+        if (document.readyState === 'loading') {
+          document.addEventListener('DOMContentLoaded', function() {
+            injectScript();
+          });
+          return 'waiting-for-dom';
+        } else {
+          return injectScript();
+        }
+      })()
+    `
+
+    chrome.devtools.inspectedWindow.eval(injectionScript, (result, error) => {
+      if (error) {
+        console.error("Script injection error:", error)
+        reject(new Error(`Injection failed: ${error.description || error.message}`))
+        return
+      }
+
+      console.log("Injection result:", result)
+
+      if (result === "already-injected") {
+        console.log("Backend script already injected")
+        resolve()
+      } else if (result === "injected" || result === "waiting-for-dom") {
+        resolve()
+      } else {
+        reject(new Error(`Unexpected injection result: ${result}`))
+      }
+    })
   })
 }
 
-connect()
+// Handle page navigation
+function onReload(reloadFunction) {
+  chrome.devtools.network.onNavigated.addListener(() => {
+    console.log("Page navigated, reconnecting...")
+
+    // Disconnect current port if exists
+    if (currentPort) {
+      currentPort.disconnect()
+      currentPort = null
+    }
+
+    // Reset connection state
+    isConnecting = false
+    connectionAttempts = 0
+
+    // Add a delay to ensure page is ready
+    setTimeout(reloadFunction, 100)
+  })
+}
+
+// Handle tab updates (refresh, etc.)
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (tabId === chrome.devtools.inspectedWindow.tabId && changeInfo.status === "complete") {
+    console.log("Tab updated and complete, ensuring connection...")
+
+    // Only reconnect if we don't have an active connection
+    if (!currentPort || !isConnecting) {
+      setTimeout(() => connect(), 200)
+    }
+  }
+})
+
 onReload(() => {
   connect()
+})
+connect()
+
+export default mount(App, {
+  target: document.querySelector("#app"),
 })

--- a/src/browser_panel/proxy.js
+++ b/src/browser_panel/proxy.js
@@ -3,6 +3,7 @@
 // to the chrome runtime API. It serves as a proxy between the injected
 // backend and the DevTool panel.
 import { HOTWIRE_DEV_TOOLS_BACKEND_SOURCE, HOTWIRE_DEV_TOOLS_PROXY_SOURCE, PROXY } from "./ports"
+import { PANEL_TO_BACKEND_MESSAGES } from "../lib/constants"
 
 function proxy() {
   const proxyPort = chrome.runtime.connect({
@@ -13,7 +14,7 @@ function proxy() {
   window.addEventListener("message", sendMessageToDevtools)
   proxyPort.onDisconnect.addListener(handleDisconnect)
 
-  sendMessageToBackend("init")
+  sendMessageToBackend(PANEL_TO_BACKEND_MESSAGES.INIT)
 
   function sendMessageToBackend(payload) {
     window.postMessage(
@@ -34,7 +35,7 @@ function proxy() {
   function handleDisconnect() {
     proxyPort.onMessage.removeListener(sendMessageToBackend)
     window.removeEventListener("message", sendMessageToDevtools)
-    sendMessageToBackend("shutdown")
+    sendMessageToBackend(PANEL_TO_BACKEND_MESSAGES.SHUTDOWN)
   }
 }
 

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -4,13 +4,13 @@ export const BACKEND_TO_PANEL_MESSAGES = {
 }
 
 export const PANEL_TO_BACKEND_MESSAGES = {
-  // shutdown is triggered from proxy.js
+  // Triggered by the Proxy
+  INIT: "init",
   SHUTDOWN: "shutdown",
 
+  // Triggered by the Panel itself
   HOVER_COMPONENT: "hover",
   HIDE_HOVER: "hide-hover",
   GET_TURBO_FRAMES: "get-turbo-frames",
   REFRESH_TURBO_FRAME: "refresh-turbo-frame",
 }
-
-export const CONTENT_TO_BACKGROUND_MESSAGES = {}


### PR DESCRIPTION
This PR adds a couple of changes on the (re)connection handling of the devtool panel. 
More precisely, how we add the `backend.js` script to the page and how we handle page reloads.   

Previously, when the page was reloaded, or an link with the `target="_top"` attribute was clicked, while the devtool panel was open, there was a high chance that the `backend.js` script was not reinjected into the page. Therefore, the connection between the panel and the page was lost. 