### PR TITLE
Fix Turbo Frame re-rendering bug

### DIFF
--- a/src/browser_panel/page/backend.js
+++ b/src/browser_panel/page/backend.js
@@ -39,9 +39,14 @@ function init() {
       const frameMap = new Map()
 
       allFrames.forEach((frame) => {
+        let uuid = frame.getAttribute("data-hotwire-dev-tools-uuid")
+        if (!uuid) {
+          uuid = generateUUID()
+          frame.setAttribute("data-hotwire-dev-tools-uuid", uuid)
+        }
         const data = {
           id: frame.id,
-          uuid: generateUUID(),
+          uuid: uuid,
           src: frame.src,
           loading: frame.getAttribute("loading"),
           innerHTML: frame.innerHTML,

--- a/src/browser_panel/panel/tabs/TurboTab.svelte
+++ b/src/browser_panel/panel/tabs/TurboTab.svelte
@@ -208,7 +208,7 @@
           </div>
           <div class="scrollable-list">
             {#if turboStreams.length > 0}
-              {#each turboStreams as stream}
+              {#each turboStreams as stream (stream.uuid)}
                 <div
                   {@attach scrollIntoView}
                   class="entry-row p-1 cursor-pointer"
@@ -272,7 +272,7 @@
       <!-- Recursively render children -->
       {#if hasChildren}
         <div class="children-container" class:collapsed={isCollapsed}>
-          {#each frame.children as child}
+          {#each frame.children as child (child.uuid)}
             {@render turboFrameRow(child, depth + 1)}
           {/each}
         </div>
@@ -290,7 +290,7 @@
           </div>
           <div class="scrollable-list">
             {#if turboFrames.length > 0}
-              {#each turboFrames as frame}
+              {#each turboFrames as frame (frame.uuid)}
                 {@render turboFrameRow(frame)}
               {/each}
             {:else}


### PR DESCRIPTION
This PR fixes a bug, where the Svelte state got confused, which Turbo Frame got already rendered and which hasn't.  

Example:
```
// After reopening a page and the extension panel I see this Turbo Frame entry:
entry-A: #week-2024-05-06 - true - 22:16:52

// Couple seconds later, a new frame gets pushed:
entry-B: #week-2024-03-04 - false - 22:16:52
entry-A: #week-2024-05-06 - true - 22:17:26
```

The debug-time doesn't really make sense. It thinks that it already rendered `#week-2024-03-04`, even though it was just pushed.
And the existing frame `#week-2024-05-06` got the new time, as it was re-rendered