### PR TITLE
Implement Sticky Entry Rows Functionality

### DIFF
--- a/public/styles/dev_tool_panel.css
+++ b/public/styles/dev_tool_panel.css
@@ -142,6 +142,15 @@ svg.icon-muted {
   --indent-size: 1rem;
   padding-left: calc(var(--depth, 0) * var(--indent-size) + 0.5rem);
 }
+
+.entry-row.sticky-parent {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background-color: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
 .entry-row:hover {
   background-color: var(--hover-for-select-bg);
 }

--- a/src/utils/collapsible.js
+++ b/src/utils/collapsible.js
@@ -1,0 +1,78 @@
+export const collapseEntryRows = (uuid, event, collapsibles, stickyParents) => {
+  event.stopPropagation()
+
+  const isCurrentlyCollapsed = collapsibles[uuid] || false
+  const frameElement = event.target.closest(".entry-row")
+  const containerElement = frameElement.nextElementSibling
+
+  if (containerElement && containerElement.classList.contains("children-container")) {
+    if (isCurrentlyCollapsed) {
+      // Expanding
+      containerElement.classList.remove("collapsed")
+      containerElement.style.height = "0px"
+      containerElement.offsetHeight
+
+      const targetHeight = containerElement.scrollHeight
+      containerElement.style.height = `${targetHeight}px`
+      setTimeout(() => {
+        containerElement.style.height = ""
+        if (stickyParents) {
+          toggleStickyParent(uuid, frameElement, true, stickyParents)
+        }
+      }, 300) // Match the transition duration in CSS
+    } else {
+      // Collapsing
+      const startHeight = containerElement.scrollHeight
+      containerElement.style.height = `${startHeight}px`
+      containerElement.offsetHeight
+
+      containerElement.style.height = "0px"
+      if (stickyParents) {
+        toggleStickyParent(uuid, frameElement, false, stickyParents)
+      }
+      setTimeout(() => {
+        containerElement.classList.add("collapsed")
+      }, 300) // Match the transition duration
+    }
+  }
+
+  collapsibles[uuid] = !isCurrentlyCollapsed
+}
+
+export const toggleStickyParent = (uuid, frameElement, makeSticky, stickyParents) => {
+  if (makeSticky) {
+    frameElement.classList.add("sticky-parent")
+    stickyParents[uuid] = frameElement
+  } else {
+    frameElement.classList.remove("sticky-parent")
+    delete stickyParents[uuid]
+  }
+}
+
+export const checkStickyVisibility = (scrollableList, stickyParents, collapsibles) => {
+  if (!scrollableList) return
+
+  Object.entries(stickyParents).forEach(([uuid, frameElement]) => {
+    const containerElement = frameElement.nextElementSibling
+    if (!containerElement || !containerElement.classList.contains("children-container")) return
+
+    const isCurrentlyCollapsed = collapsibles[uuid] || false
+    if (isCurrentlyCollapsed) {
+      frameElement.classList.remove("sticky-parent")
+      return
+    }
+
+    const children = Array.from(containerElement.querySelectorAll(".entry-row"))
+    const isAnyChildVisible = children.some((child) => {
+      const rect = child.getBoundingClientRect()
+      const parentRect = scrollableList.getBoundingClientRect()
+      return rect.bottom > parentRect.top && rect.top < parentRect.bottom
+    })
+
+    if (isAnyChildVisible) {
+      frameElement.classList.add("sticky-parent")
+    } else {
+      frameElement.classList.remove("sticky-parent")
+    }
+  })
+}


### PR DESCRIPTION
This PR introduces the ability to mark specific entry rows as sticky.

The initial use case targets Turbo Frames that contain child Turbo Frames. This way their entry rows remain sticky at the top of the viewport as users scroll.

https://github.com/user-attachments/assets/f2541eaf-8963-4d01-96ab-6e4bb497ee8b

