### PR TITLE
Ensure backend connection survives page reloads on Safari

### DIFF
--- a/public/styles/dev_tool_panel.css
+++ b/public/styles/dev_tool_panel.css
@@ -441,6 +441,21 @@ svg.icon-muted {
   margin-right: 0.5rem;
 }
 
+.m-1 {
+  margin: 0.25rem;
+}
+.m-2 {
+  margin: 0.5rem;
+}
+.m-3 {
+  margin: 1rem;
+}
+.m-4 {
+  margin: 1.5rem;
+}
+.m-5 {
+  margin: 3rem;
+}
 .gap-0 {
   gap: 0;
 }

--- a/src/browser_panel/State.svelte.js
+++ b/src/browser_panel/State.svelte.js
@@ -1,3 +1,25 @@
+export function createConnectionState() {
+  let connectedToBackend = $state(false)
+  let isPermanentlyDisconnected = $state(false)
+
+  return {
+    get isPermanentlyDisconnected() {
+      return isPermanentlyDisconnected
+    },
+    set isPermanentlyDisconnected(value) {
+      isPermanentlyDisconnected = value
+    },
+
+    get connectedToBackend() {
+      return connectedToBackend
+    },
+    set connectedToBackend(value) {
+      connectedToBackend = value
+    },
+  }
+}
+export const connection = createConnectionState()
+
 let turboFrames = $state([])
 let turboStreams = $state([])
 

--- a/src/browser_panel/messaging.js
+++ b/src/browser_panel/messaging.js
@@ -24,6 +24,7 @@ export function handleBackendToPanelMessage(message, port) {
       break
     case BACKEND_TO_PANEL_MESSAGES.HEALTH_CHECK_RESPONSE:
       setPort(port)
+      break
     default:
       console.warn(`Unknown message type from backend: ${message.type}`)
   }

--- a/src/browser_panel/messaging.js
+++ b/src/browser_panel/messaging.js
@@ -22,6 +22,8 @@ export function handleBackendToPanelMessage(message, port) {
       addTurboStream(message.turboStream)
       setPort(port)
       break
+    case BACKEND_TO_PANEL_MESSAGES.HEALTH_CHECK_RESPONSE:
+      setPort(port)
     default:
       console.warn(`Unknown message type from backend: ${message.type}`)
   }

--- a/src/browser_panel/page/backend.js
+++ b/src/browser_panel/page/backend.js
@@ -151,6 +151,12 @@ function init() {
         this.observer = null
       }
     }
+
+    respondToHealthCheck() {
+      this._postMessage({
+        type: BACKEND_TO_PANEL_MESSAGES.HEALTH_CHECK_RESPONSE,
+      })
+    }
   }
 
   // Using a function scope to avoid running into issues on re-injection
@@ -177,6 +183,10 @@ function init() {
       return
     }
     switch (e.data.payload.action) {
+      case PANEL_TO_BACKEND_MESSAGES.HEALTH_CHECK: {
+        devtoolsBackend.respondToHealthCheck()
+        break
+      }
       case PANEL_TO_BACKEND_MESSAGES.GET_TURBO_FRAMES: {
         devtoolsBackend.sendTurboFrames()
         break

--- a/src/browser_panel/panel/App.svelte
+++ b/src/browser_panel/panel/App.svelte
@@ -18,6 +18,7 @@
   import { getDevtoolInstance, setDevtoolInstance } from "$lib/devtool.js"
   import { handleResize } from "../theme.svelte.js"
   import TurboTab from "./tabs/TurboTab.svelte"
+  import { connection } from "../State.svelte.js"
 
   setDevtoolInstance()
   const devTool = getDevtoolInstance()
@@ -51,7 +52,18 @@
   }
 </script>
 
-{#if devToolOptionsLoaded}
+{#if connection.isPermanentlyDisconnected}
+  <sl-alert variant="danger" class="m-5" open>
+    <sl-icon slot="icon" name="exclamation-octagon"></sl-icon>
+    <strong>Connection Timeout</strong><br />
+    Unable to connect to the current page. Try closing and reopening the inspection panel to resolve the issue.
+    <div class="mt-4">
+      If this issue persists, consider reporting it on GitHub:
+      <br />
+      <a href="https://github.com/leonvogt/hotwire-dev-tools/issues/new" target="_blank" rel="noopener noreferrer">https://github.com/leonvogt/hotwire-dev-tools/issues/new</a>
+    </div>
+  </sl-alert>
+{:else if devToolOptionsLoaded}
   <main {@attach addEventListeners}>
     <div id="container">
       <div class="tablist">

--- a/src/browser_panel/panel/panel.js
+++ b/src/browser_panel/panel/panel.js
@@ -37,7 +37,11 @@ async function connect() {
     currentPort = createConnection()
     console.log(`Connected successfully (attempt ${connectionAttempts})`)
     connectionAttempts = 0
-    startHealthCheck()
+    if (__IS_SAFARI__) {
+      // Health checks are only needed for Safari because it doesn't trigger the `port.onDisconnect` event consistently.
+      // More: https://github.com/leonvogt/hotwire-dev-tools/pull/123
+      startHealthCheck()
+    }
   } catch (error) {
     console.warn(`Connection failed (attempt ${connectionAttempts}/${maxConnectionAttempts}):`, error)
 

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -10,6 +10,7 @@ export const PORT_IDENTIFIERS = {
 export const BACKEND_TO_PANEL_MESSAGES = {
   SET_TURBO_FRAMES: "set-turbo-frames",
   TURBO_STREAM_RECEIVED: "turbo-stream-received",
+  HEALTH_CHECK_RESPONSE: "health-check-response",
 }
 
 export const PANEL_TO_BACKEND_MESSAGES = {
@@ -18,6 +19,7 @@ export const PANEL_TO_BACKEND_MESSAGES = {
   SHUTDOWN: "shutdown",
 
   // Triggered by the Panel itself
+  HEALTH_CHECK: "healt-check",
   HOVER_COMPONENT: "hover",
   HIDE_HOVER: "hide-hover",
   GET_TURBO_FRAMES: "get-turbo-frames",


### PR DESCRIPTION
PR #119 attempted to solve the issue where, after reloading the page or clicking a link with `target="_top"`, the connection to the backend script was lost.

Problem: The solution in #119 did not work in Safari.
In Safari, the `port.onDisconnect` event is not triggered consistently. More information can be found at lapcat/SafariExtensions#40.

Since we therefore don't have a reliable way to detect a disconnect, this PR implements a health check approach.
The panel now regularly sends a health check message to the backend script.
If it doesn't receive a response within a certain time frame, we assume the connection is lost and attempt to reconnect.

It's not the most elegant solution, but for now, I don't see a better way to continue maintaining Safari support.

---

In addition, this PR introduces a new connection-related Svelte state for tracking the connection status. Currently, it's only used to display a warning message when the maximum reconnect attempts are reached. However, we could also use it in the future to display an online/offline status in the UI.