### PR TITLE
Monitor Turbo Stream WebSocket connections

### DIFF
--- a/src/browser_panel/State.svelte.js
+++ b/src/browser_panel/State.svelte.js
@@ -21,14 +21,23 @@ export function createConnectionState() {
 export const connection = createConnectionState()
 
 let turboFrames = $state([])
+let turboCables = $state([])
 let turboStreams = $state([])
 
-export function setTurboFrames(frames) {
+export function setTurboFrames(frames, url) {
   turboFrames = frames
 }
 
 export function getTurboFrames() {
   return turboFrames
+}
+
+export function setTurboCables(cables, url) {
+  turboCables = cables
+}
+
+export function getTurboCables() {
+  return turboCables
 }
 
 export function addTurboStream(turboStream) {

--- a/src/browser_panel/messaging.js
+++ b/src/browser_panel/messaging.js
@@ -1,5 +1,5 @@
 import { BACKEND_TO_PANEL_MESSAGES, PORT_IDENTIFIERS } from "$lib/constants"
-import { setTurboFrames, addTurboStream } from "./State.svelte.js"
+import { setTurboFrames, setTurboCables, addTurboStream } from "./State.svelte.js"
 
 function setPort(port) {
   if (!window.__HotwireDevTools) {
@@ -16,6 +16,10 @@ export function handleBackendToPanelMessage(message, port) {
   switch (message.type) {
     case BACKEND_TO_PANEL_MESSAGES.SET_TURBO_FRAMES:
       setTurboFrames(message.frames, message.url)
+      setPort(port)
+      break
+    case BACKEND_TO_PANEL_MESSAGES.SET_TURBO_CABLES:
+      setTurboCables(message.turboCables, message.url)
       setPort(port)
       break
     case BACKEND_TO_PANEL_MESSAGES.TURBO_STREAM_RECEIVED:

--- a/src/browser_panel/page/element_observer.js
+++ b/src/browser_panel/page/element_observer.js
@@ -1,0 +1,120 @@
+export default class ElementObserver {
+  constructor(element, delegate) {
+    this.element = element
+    this.delegate = delegate
+    this.started = false
+    this.elements = new Set()
+
+    this.mutationObserver = new MutationObserver((mutations) => this.processMutations(mutations))
+
+    this.mutationObserverInit = {
+      attributes: true,
+      childList: true,
+      subtree: true,
+      attributeOldValue: true,
+    }
+  }
+
+  start() {
+    if (!this.started) {
+      this.started = true
+      this.mutationObserver.observe(this.element, this.mutationObserverInit)
+      this.refresh()
+    }
+  }
+
+  stop() {
+    if (this.started) {
+      this.mutationObserver.takeRecords()
+      this.mutationObserver.disconnect()
+      this.started = false
+    }
+  }
+
+  refresh() {
+    if (this.started) {
+      const elements = this.matchElementsInTree()
+      for (const element of elements) {
+        this.matchElement(element)
+      }
+    }
+  }
+
+  matchElementsInTree(tree = this.element) {
+    return this.delegate.matchElementsInTree(tree)
+  }
+
+  matchElement(element) {
+    if (!this.elements.has(element) && this.delegate.matchElement(element)) {
+      this.elements.add(element)
+      if (this.delegate.elementMatched) {
+        this.delegate.elementMatched(element)
+      }
+    }
+  }
+
+  processMutations(mutations) {
+    if (this.started) {
+      for (const mutation of mutations) {
+        this.processMutation(mutation)
+      }
+    }
+  }
+
+  processMutation(mutation) {
+    if (mutation.type === "childList") {
+      this.processRemovedNodes(mutation.removedNodes)
+      this.processAddedNodes(mutation.addedNodes)
+    } else if (mutation.type === "attributes") {
+      this.processAttributeChange(mutation.target, mutation.attributeName, mutation.oldValue)
+    }
+  }
+
+  processRemovedNodes(nodes) {
+    for (const node of Array.from(nodes)) {
+      const element = this.elementFromNode(node)
+      if (element) {
+        this.processTree(element, this.removeElement)
+      }
+    }
+  }
+
+  processAddedNodes(nodes) {
+    for (const node of Array.from(nodes)) {
+      const element = this.elementFromNode(node)
+      if (element) {
+        this.processTree(element, this.matchElement)
+      }
+    }
+  }
+
+  processAttributeChange(node, attributeName, oldValue) {
+    const element = this.elementFromNode(node)
+    if (element && this.elements.has(element)) {
+      if (this.delegate.elementAttributeChanged) {
+        this.delegate.elementAttributeChanged(element, attributeName, oldValue)
+      }
+    }
+  }
+
+  elementFromNode(node) {
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      return node
+    }
+  }
+
+  processTree(tree, processor) {
+    for (const element of this.matchElementsInTree(tree)) {
+      processor.call(this, element)
+    }
+  }
+
+  removeElement(element) {
+    if (this.elements.has(element)) {
+      this.elements.delete(element)
+      if (this.delegate.elementUnmatched) {
+        this.delegate.elementUnmatched(element)
+      }
+    }
+  }
+}

--- a/src/browser_panel/page/turbo_cable_observer.js
+++ b/src/browser_panel/page/turbo_cable_observer.js
@@ -1,0 +1,72 @@
+import { ensureUUIDOnElement, getUUIDFromElement, stringifyHTMLElementTag } from "$utils/utils.js"
+
+// The TurboCableObserver class is responsible for observing `<turbo-cable-stream-source>` elements,
+// which are used in Turbo Streams to manage WebSocket connections.
+export default class TurboCableObserver {
+  constructor(delegate) {
+    this.delegate = delegate
+    this.streamSources = new Map() // UUID -> Turbo Cable Stream Source data
+  }
+
+  matchElement(element) {
+    return element.tagName?.toLowerCase() === "turbo-cable-stream-source"
+  }
+
+  matchElementsInTree(tree) {
+    const match = this.matchElement(tree) ? [tree] : []
+    const matches = Array.from(tree.querySelectorAll("turbo-cable-stream-source"))
+    return match.concat(matches)
+  }
+
+  elementMatched(element) {
+    const uuid = ensureUUIDOnElement(element)
+
+    if (!this.streamSources.has(uuid)) {
+      const turboCableData = this.buildTurboCableData(element)
+      this.streamSources.set(uuid, turboCableData)
+      this.delegate.turboCableConnected(element)
+    }
+  }
+
+  elementUnmatched(element) {
+    const uuid = getUUIDFromElement(element)
+
+    if (this.streamSources.has(uuid)) {
+      this.streamSources.delete(uuid)
+      this.delegate.turboCableDisconnected(element)
+    }
+  }
+
+  elementAttributeChanged(element, attributeName, oldValue) {
+    if (this.matchElement(element)) {
+      const uuid = getUUIDFromElement(element)
+      if (this.streamSources.has(uuid)) {
+        const turboCableData = this.streamSources.get(uuid)
+        const newValue = element.getAttribute(attributeName)
+
+        if (newValue === null) {
+          delete turboCableData.attributes[attributeName]
+        } else {
+          turboCableData.attributes[attributeName] = newValue
+        }
+        turboCableData.connected = element.hasAttribute("connected")
+
+        this.delegate.turboCableAttributeChanged(element, attributeName, oldValue, newValue)
+      }
+    }
+  }
+
+  buildTurboCableData(element) {
+    return {
+      connected: element.hasAttribute("connected"),
+      attributes: Array.from(element.attributes).reduce((map, attr) => {
+        map[attr.name] = attr.value
+        return map
+      }, {}),
+    }
+  }
+
+  getTurboCableData() {
+    return Array.from(this.streamSources.values())
+  }
+}

--- a/src/browser_panel/page/turbo_frame_observer.js
+++ b/src/browser_panel/page/turbo_frame_observer.js
@@ -1,129 +1,118 @@
+import { ensureUUIDOnElement, getUUIDFromElement, stringifyHTMLElementTag } from "$utils/utils.js"
+
 export default class TurboFrameObserver {
-  constructor(delegate = {}) {
-    this.element = document
-    this.started = false
+  constructor(delegate) {
     this.delegate = delegate
-    this.frames = new Set()
-
-    this.mutationObserver = new MutationObserver((mutations) => this.processMutations(mutations))
-    this.mutationObserverInit = { attributes: true, childList: true, subtree: true, attributeOldValue: true }
+    this.frames = new Map() // UUID -> frame data
   }
 
-  start() {
-    if (!this.started) {
-      this.started = true
-      this.mutationObserver.observe(this.element, this.mutationObserverInit)
-      this.refresh()
-    }
+  matchElement(element) {
+    return element.tagName?.toLowerCase() === "turbo-frame"
   }
 
-  stop() {
-    if (this.started) {
-      this.mutationObserver.takeRecords()
-      this.mutationObserver.disconnect()
-      this.started = false
-    }
+  matchElementsInTree(tree) {
+    const match = this.matchElement(tree) ? [tree] : []
+    const matches = Array.from(tree.querySelectorAll("turbo-frame"))
+    return match.concat(matches)
   }
 
-  refresh() {
-    if (this.started) {
-      const frames = new Set(this.findAllTurboFrames())
+  elementMatched(element) {
+    const uuid = ensureUUIDOnElement(element)
 
-      // Remove frames that no longer exist
-      for (const frame of Array.from(this.frames)) {
-        if (!frames.has(frame)) {
-          this.removeFrame(frame)
-        }
-      }
+    if (!this.frames.has(uuid)) {
+      const frameData = this.buildFrameData(element)
+      this.frames.set(uuid, frameData)
 
-      // Add new frames
-      for (const frame of Array.from(frames)) {
-        if (!this.frames.has(frame)) {
-          this.addFrame(frame)
-        }
-      }
-    }
-  }
-
-  processMutations(mutations) {
-    if (this.started) {
-      for (const mutation of mutations) {
-        this.processMutation(mutation)
-      }
-    }
-  }
-
-  processMutation(mutation) {
-    if (mutation.type === "childList") {
-      this.processRemovedNodes(mutation.removedNodes)
-      this.processAddedNodes(mutation.addedNodes)
-    } else if (mutation.type === "attributes") {
-      this.processAttributeChange(mutation.target, mutation.attributeName, mutation.oldValue)
-    }
-  }
-
-  processAttributeChange(element, attributeName, oldValue) {
-    if (this.isTurboFrame(element) && this.frames.has(element)) {
-      const newValue = element.getAttribute(attributeName)
-      if (this.delegate.frameAttributeChanged) {
-        this.delegate.frameAttributeChanged(element, attributeName, oldValue, newValue)
-      }
-    }
-  }
-
-  processRemovedNodes(nodes) {
-    for (const node of Array.from(nodes)) {
-      if (this.isTurboFrame(node)) {
-        this.removeFrame(node)
-      }
-
-      if (node.querySelectorAll) {
-        const frames = node.querySelectorAll("turbo-frame")
-        for (const frame of frames) {
-          this.removeFrame(frame)
-        }
-      }
-    }
-  }
-
-  processAddedNodes(nodes) {
-    for (const node of Array.from(nodes)) {
-      if (this.isTurboFrame(node)) {
-        this.addFrame(node)
-      }
-
-      if (node.querySelectorAll) {
-        const frames = node.querySelectorAll("turbo-frame")
-        for (const frame of frames) {
-          this.addFrame(frame)
-        }
-      }
-    }
-  }
-
-  isTurboFrame(node) {
-    return node.nodeType === Node.ELEMENT_NODE && node.tagName.toLowerCase() === "turbo-frame"
-  }
-
-  findAllTurboFrames() {
-    return Array.from(document.querySelectorAll("turbo-frame"))
-  }
-
-  addFrame(frame) {
-    if (!this.frames.has(frame)) {
-      this.frames.add(frame)
       if (this.delegate.frameConnected) {
-        this.delegate.frameConnected(frame)
+        this.delegate.frameConnected(element)
       }
     }
   }
 
-  removeFrame(frame) {
-    if (this.frames.has(frame)) {
-      this.frames.delete(frame)
+  elementUnmatched(element) {
+    const uuid = getUUIDFromElement(element)
+
+    if (this.frames.has(uuid)) {
+      this.frames.delete(uuid)
+
       if (this.delegate.frameDisconnected) {
-        this.delegate.frameDisconnected(frame)
+        this.delegate.frameDisconnected(element)
       }
     }
+  }
+
+  elementAttributeChanged(element, attributeName, oldValue) {
+    if (this.matchElement(element)) {
+      const uuid = getUUIDFromElement(element)
+      if (this.frames.has(uuid)) {
+        const frameData = this.frames.get(uuid)
+        const newValue = element.getAttribute(attributeName)
+
+        if (newValue === null) {
+          delete frameData.attributes[attributeName]
+        } else {
+          frameData.attributes[attributeName] = newValue
+        }
+
+        frameData.serializedTag = stringifyHTMLElementTag(element)
+
+        if (this.delegate.frameAttributeChanged) {
+          this.delegate.frameAttributeChanged(element, attributeName, oldValue, newValue)
+        }
+      }
+    }
+  }
+
+  buildFrameData(element) {
+    return {
+      id: element.id,
+      uuid: getUUIDFromElement(element),
+      serializedTag: stringifyHTMLElementTag(element),
+      attributes: Array.from(element.attributes).reduce((map, attr) => {
+        map[attr.name] = attr.value
+        return map
+      }, {}),
+      children: [],
+      element,
+    }
+  }
+
+  getFrameData() {
+    const buildFrameTree = () => {
+      const rootFrames = []
+      this.frames.forEach((frameData) => {
+        frameData.children = []
+      })
+
+      this.frames.forEach((frameData) => {
+        const element = frameData.element
+        const parentElement = element.parentElement?.closest("turbo-frame")
+
+        if (parentElement) {
+          const parentUUID = getUUIDFromElement(parentElement)
+          if (parentUUID && this.frames.has(parentUUID)) {
+            this.frames.get(parentUUID).children.push(frameData)
+          } else {
+            // Parent exists but not in our tracking => add as root
+            rootFrames.push(frameData)
+          }
+        } else {
+          // No parent frame => this is a root frame
+          rootFrames.push(frameData)
+        }
+      })
+
+      return rootFrames
+    }
+
+    // Remove DOM elements before sending
+    const stripDOMElements = (frameData) => {
+      const { element, children, ...cleanData } = frameData
+      const strippedChildren = children.map((child) => stripDOMElements(child))
+      return { ...cleanData, children: strippedChildren }
+    }
+
+    const frameTree = buildFrameTree()
+    return frameTree.map((frame) => stripDOMElements(frame))
   }
 }

--- a/src/browser_panel/page/turbo_frame_observer.js
+++ b/src/browser_panel/page/turbo_frame_observer.js
@@ -22,10 +22,7 @@ export default class TurboFrameObserver {
     if (!this.frames.has(uuid)) {
       const frameData = this.buildFrameData(element)
       this.frames.set(uuid, frameData)
-
-      if (this.delegate.frameConnected) {
-        this.delegate.frameConnected(element)
-      }
+      this.delegate.frameConnected(element)
     }
   }
 
@@ -34,10 +31,7 @@ export default class TurboFrameObserver {
 
     if (this.frames.has(uuid)) {
       this.frames.delete(uuid)
-
-      if (this.delegate.frameDisconnected) {
-        this.delegate.frameDisconnected(element)
-      }
+      this.delegate.frameDisconnected(element)
     }
   }
 
@@ -56,9 +50,7 @@ export default class TurboFrameObserver {
 
         frameData.serializedTag = stringifyHTMLElementTag(element)
 
-        if (this.delegate.frameAttributeChanged) {
-          this.delegate.frameAttributeChanged(element, attributeName, oldValue, newValue)
-        }
+        this.delegate.frameAttributeChanged(element, attributeName, oldValue, newValue)
       }
     }
   }

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -9,6 +9,7 @@ export const PORT_IDENTIFIERS = {
 
 export const BACKEND_TO_PANEL_MESSAGES = {
   SET_TURBO_FRAMES: "set-turbo-frames",
+  SET_TURBO_CABLES: "set-turbo-cables",
   TURBO_STREAM_RECEIVED: "turbo-stream-received",
   HEALTH_CHECK_RESPONSE: "health-check-response",
 }


### PR DESCRIPTION
This PR adds an indicator to display the Turbo Stream WebSocket connection status. A green dot appears when connected, and a red dot indicates that one or more connections are lost.

To monitor `<turbo-cable-stream-source>` elements, the mutation observer approach introduced in #124 has been refactored to support tracking multiple elements using a single MutationObserver.
The implementation is heavily inspired by [Stimulus](https://github.com/hotwired/stimulus), which features an excellent abstraction of `MutationObserver` logic in their codebase.